### PR TITLE
Make tests work on Windows

### DIFF
--- a/lib/tension.js
+++ b/lib/tension.js
@@ -4,7 +4,7 @@ const { IS_OK , IS_INCOMPLETE , IS_TIMEOUT , IS_LIE , IS_SKIPPED , IS_CRASHED } 
 
 async function reason(filePath, config) {
     return new Promise( (resolve) => {
-        if (config.type === 'skip' || ! filePath.match(/\/pure\//g)) {
+        if (config.type === 'skip' || ! filePath.match(/[\\/]pure[\\/]/g)) {
             resolve(IS_SKIPPED);
             return;
         }


### PR DESCRIPTION
The Windows file paths will have backslashes in them instead of forward slashes.