### PR TITLE
Stop spawned processes after timeout

### DIFF
--- a/config.json-example
+++ b/config.json-example
@@ -11,8 +11,8 @@
         "timeout": "10"
     },
     "tension": {
-        "path": "timeout 10s $HOME/github.com/joachimvh/tension.js/bin/tension.js",
-        "args": "-f",
+        "path": "node",
+        "args": "$HOME/github.com/joachimvh/tension.js/bin/tension.js -f",
         "timeout": "10"
     },
     "latar": {

--- a/lib/tension.js
+++ b/lib/tension.js
@@ -1,5 +1,5 @@
 const fs  = require('fs');
-const exec = require('child_process').exec;
+const spawn = require('child_process').spawn;
 const { IS_OK , IS_INCOMPLETE , IS_TIMEOUT , IS_LIE , IS_SKIPPED , IS_CRASHED } = require('../lib/errors');
 
 async function reason(filePath, config) {
@@ -10,20 +10,22 @@ async function reason(filePath, config) {
         }
 
         try {
-            const command = `${config.tension.path} ${config.tension.args} ${filePath} > ${filePath}.out 2>&1`;
-            exec(command, { 
-                timeout: config.tension.timeout * 1000 ,
-                killSignal: 'SIGKILL',
+            const proc = spawn(config.tension.path, [...config.tension.args.split(' '), filePath], {
+                timeout: config.tension.timeout * 1000,
                 windowsHide: true
-            } , (error) => {
-                if (error && error.killed) {
-                    resolve(IS_TIMEOUT);
-                    return;
-                }
+            });
+            let output = '';
+            proc.stdout.on('data', (data) => {
+              output += data;
+            });
+            proc.stderr.on('data', (data) => {
+              output += data;
+            });
 
-                const output = fs.readFileSync(`${filePath}.out`, { encoding: 'utf-8'});
-
-                if (config.type == 'normal' && output.match(/.*:test.*is.*true/g)) {
+            proc.on('exit', (code, signal) => {
+                if (signal === 'SIGTERM') {
+                  resolve(IS_TIMEOUT);
+                } else if (config.type == 'normal' && output.match(/.*:test.*is.*true/g)) {
                     resolve(IS_OK);
                 }
                 else if (config.type == 'normal' && output.match(/Found a contradiction at root level/g)) {


### PR DESCRIPTION
Closes https://github.com/eyereasoner/rdfsurfaces-tests/issues/3

Using `spawn` instead of `exec` does stop the node processes after the timeout. How to call the spawn function differs a bit from how to call `exec` though as can be seen in the changes of the example config, so might make sense to change the fields of the config.

Would perhaps not immediately merge this as it only changes 1 reasoner, but can be used as an example.